### PR TITLE
Fixed compilation on windows

### DIFF
--- a/core/ctree/cnode.cpp
+++ b/core/ctree/cnode.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <ctime>
 #include "cnode.h"
 
 namespace tree{
@@ -376,9 +377,7 @@ namespace tree{
 
     void cbatch_traverse(CRoots *roots, int pb_c_base, float pb_c_init, float discount, tools::CMinMaxStatsList *min_max_stats_lst, CSearchResults &results){
         // set seed
-        timeval t1;
-        gettimeofday(&t1, NULL);
-        srand(t1.tv_usec);
+        srand((unsigned) time(NULL));
 
         int last_action = -1;
         float parent_q = 0.0;

--- a/core/ctree/cnode.h
+++ b/core/ctree/cnode.h
@@ -8,8 +8,6 @@
 #include <stdlib.h>
 #include <time.h>
 #include <cmath>
-#include <sys/timeb.h>
-#include <sys/time.h>
 
 const int DEBUG_MODE = 0;
 


### PR DESCRIPTION
sys/time.h is not available for windows, ctime works for every system since is part of c++ libs
Signed-off-by: lobotuerk <tomas.lobo.it@gmail.com>