### PR TITLE
Implement augment for AFK. Add in augments to the player. Add in a method to choose an augment.

### DIFF
--- a/Simulator/augments.py
+++ b/Simulator/augments.py
@@ -1,0 +1,53 @@
+from enum import Enum, auto
+from re import match
+
+
+class Augment(Enum):
+    AFK = auto()
+
+    @staticmethod
+    def is_augment_round(round_:int) -> bool:
+        return round_ in [3,10,17]
+
+
+class SelectedAugmentConfig:
+    round: int
+    augment: Augment
+
+    def __init__(self, augment: Augment, round_: int):
+        self.round = round_
+        self.augment = augment
+
+
+def handle_start_round_augment(player, augment_config: SelectedAugmentConfig):
+    """
+    Handle modifications to the player at the start of the round
+    """
+    if augment_config.augment == Augment.AFK:
+        afk_augment_get_golds(player,augment_config)
+
+
+
+def handle_can_perform_action_augment(round_:int, augment_config:SelectedAugmentConfig)-> bool:
+    """
+    Check if the player can perform an action based on the augment
+    """
+    if augment_config.augment == Augment.AFK:
+        return afk_augment_can_perform_action(round_, augment_config)
+    return True
+
+
+
+def afk_augment_get_golds(player, augment_config: SelectedAugmentConfig):
+    """
+    Update the player gold after the afk augment become inactive
+    """
+    if player.round == augment_config.round + 3:
+        player.gold += 20
+
+
+def afk_augment_can_perform_action(round_:int, augment_config: SelectedAugmentConfig) -> bool:
+    """
+    Check if the afk augment is active
+    """
+    return round_ >= augment_config.round + 3

--- a/Simulator/augments.py
+++ b/Simulator/augments.py
@@ -1,5 +1,4 @@
 from enum import Enum, auto
-from re import match
 
 
 class Augment(Enum):

--- a/UnitTests/game_round_test.py
+++ b/UnitTests/game_round_test.py
@@ -9,19 +9,7 @@ from Simulator.tft_simulator import TFTConfig
 
 
 def test_single_player_combat():
-    base_level_config = {
-        "num_unique_champions": 3,
-        "max_cost": 1,
-        "num_items": 0,
-        "current_level": 3,
-        "chosen": False,
-        "sample_from_pool": False,
-        "two_star_unit_percentage": 0,
-        "three_star_unit_percentage": 0,
-        "scenario_info": True,
-        "extra_randomness": False
-    }
-    battle_generator = BattleGenerator(base_level_config)
+    battle_generator = BattleGenerator()
     [player, opponent, other_players] = battle_generator.generate_battle()
 
     PLAYER = player

--- a/UnitTests/game_round_test.py
+++ b/UnitTests/game_round_test.py
@@ -9,7 +9,19 @@ from Simulator.tft_simulator import TFTConfig
 
 
 def test_single_player_combat():
-    battle_generator = BattleGenerator()
+    base_level_config = {
+        "num_unique_champions": 3,
+        "max_cost": 1,
+        "num_items": 0,
+        "current_level": 3,
+        "chosen": False,
+        "sample_from_pool": False,
+        "two_star_unit_percentage": 0,
+        "three_star_unit_percentage": 0,
+        "scenario_info": True,
+        "extra_randomness": False
+    }
+    battle_generator = BattleGenerator(base_level_config)
     [player, opponent, other_players] = battle_generator.generate_battle()
 
     PLAYER = player


### PR DESCRIPTION
- added Augment enum with Augment.AFK and some helpers 
- added Augment.AFK automatically on player.start_round if it's augment choice round
- added augments attribute and add_augment method  to store augments in Player
- added is_afk attribute in Player to handle if player has afk augment active
- updated step method in TFT_Simulator to force action Pass if player is afk